### PR TITLE
Supporting working with LuaJIT 2.1.x

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ MACOSX_VERSION = 10.4
 CMOD = zlib.so
 OBJS = lua_zlib.o
 
-LIBS = -lz -llua -lm
+LIBS = -lz -lm
 WARN = -Wall -pedantic
 
 BSD_CFLAGS  = -O2 -fPIC $(WARN) $(INCDIR) $(DEFS)


### PR DESCRIPTION
The goal of this pull request is to get this library building with http://luajit.org/ so that it can be used with  https://github.com/marc-barry/docker-nginx-openresty. The https://github.com/marc-barry/docker-nginx-openresty is based upon [Alpine Linux](https://alpinelinux.org/).